### PR TITLE
Improve numberoutput

### DIFF
--- a/sounds/create-sounds.sh
+++ b/sounds/create-sounds.sh
@@ -93,7 +93,7 @@ createsnd en-GB/press-snom-reboot "please press star star hash hash"
 VOICE=Anna
 
 ## digits
-for i in {0..23} 30 40 50 60 70 80 90 und hundert tausend million millionen minus uhr; do
+for i in {0..23} 30 40 50 60 70 80 90 100 1000 1000000 und hundert tausend millionen minus uhr; do
 	createsnd de-DE/digits/$i $i
 done
 createsnd de-DE/digits/hash raute

--- a/ygi/ygi.tcl
+++ b/ygi/ygi.tcl
@@ -821,10 +821,18 @@ proc ::ygi::_en_numberfiles {number {language "en"}} {
 		return $files
 	}
 	if {$number < 1000} {
-		return [list [expr {$number / 100}] hundred and {*}[_en_numberfiles [expr {$number % 100}]]]
+		if {$number % 100} {
+			return [list [expr {$number / 100}] hundred and {*}[_en_numberfiles [expr {$number % 100}]]]
+		} else {
+			return [list [expr {$number / 100}] hundred]
+		}
 	}
 	if {$number < 1000000} {
-		return [list {*}[_en_numberfiles [expr {$number / 1000}]] thousand {*}[_en_numberfiles [expr {$number % 1000}]]]
+		if {$number % 1000} {
+			return [list {*}[_en_numberfiles [expr {$number / 1000}]] thousand {*}[_en_numberfiles [expr {$number % 1000}]]]
+		} else {
+			return [list {*}[_en_numberfiles [expr {$number / 1000}]] thousand]
+		}
 	}
 	return [split $number ""]
 }
@@ -839,11 +847,33 @@ proc ::ygi::_de_numberfiles {number {language "de"}} {
 		if {$rem} {return [list $rem und $tens]}
 		return [list $tens]
 	}
+	if {$number < 200 } {
+		if {$number % 100} {
+			return [list 100 {*}[_de_numberfiles [expr {$number % 100}]]]
+		} else {
+			return [list $number]
+		}
+	}
 	if {$number < 1000} {
-		return [list [expr {$number / 100}] hundert {*}[_de_numberfiles [expr {$number % 100}]]]
+		if {$number % 100} {
+			return [list [expr {$number / 100}] hundert {*}[_de_numberfiles [expr {$number % 100}]]]
+		} else {
+			return [list [expr {$number / 100}] hundert]
+		}
+	}
+	if {$number < 2000} {
+		if {$number % 1000} {
+			return [list 1000 {*}[_de_numberfiles [expr {$number % 1000}]]]
+		} else {
+			return [list 1000]
+		}
 	}
 	if {$number < 1000000} {
-		return [list {*}[_de_numberfiles [expr {$number / 1000}]] tausend {*}[_de_numberfiles [expr {$number % 1000}]]]
+		if {$number % 1000} {
+			return [list {*}[_de_numberfiles [expr {$number / 1000}]] tausend {*}[_de_numberfiles [expr {$number % 1000}]]]
+		} else {
+			return [list {*}[_de_numberfiles [expr {$number / 1000}]] tausend]
+		}
 	}
 	return [split $number ""]
 }

--- a/ygi/ygi.tcl
+++ b/ygi/ygi.tcl
@@ -834,6 +834,13 @@ proc ::ygi::_en_numberfiles {number {language "en"}} {
 			return [list {*}[_en_numberfiles [expr {$number / 1000}]] thousand]
 		}
 	}
+	if {$number < 1000000000} {
+		if {$number % 1000000} {
+			return [list {*}[_en_numberfiles [expr {$number / 1000000}]] million {*}[_en_numberfiles [expr {$number % 1000000}]]]
+		} else {
+			return [list {*}[_en_numberfiles [expr {$number / 1000000}]] million]
+		}
+	}
 	return [split $number ""]
 }
 
@@ -873,6 +880,20 @@ proc ::ygi::_de_numberfiles {number {language "de"}} {
 			return [list {*}[_de_numberfiles [expr {$number / 1000}]] tausend {*}[_de_numberfiles [expr {$number % 1000}]]]
 		} else {
 			return [list {*}[_de_numberfiles [expr {$number / 1000}]] tausend]
+		}
+	}
+	if {$number < 2000000} {
+		if {$number % 1000000} {
+			return [list 1000000 {*}[_de_numberfiles [expr {$number % 1000000}]]]
+		} else {
+			return [list 1000000]
+		}
+	}	
+	if {$number < 1000000000} {
+		if {$number % 1000000} {
+			return [list {*}[_de_numberfiles [expr {$number / 1000000}]] millionen {*}[_de_numberfiles [expr {$number % 1000000}]]]
+		} else {
+			return [list {*}[_de_numberfiles [expr {$number / 1000000}]] millionen]
 		}
 	}
 	return [split $number ""]


### PR DESCRIPTION
Numbers like 100, 1000,... have been spoken as 100 0, 1000 0 and the german way of speaking numbers like 100, 1000 were spoken as eins hundert, eins tausend,... Also there already have been audio files for the range 1000000..999999999 which have not yet been handled.
This pull request fixes both.